### PR TITLE
Mention installing python3-setuptools

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,7 @@ Check out the code from Github::
 
 Run install (this should install dependencies)::
 
+    sudo apt-get install python3-setuptools
     python3 setup.py install
 
 Compile the icons file for Qt::


### PR DESCRIPTION
Following instructions in the README on a fresh machine results in:

```
Traceback (most recent call last):
  File "setup.py", line 5, in <module>
    from setuptools import setup
ImportError: No module named 'setuptools'
```